### PR TITLE
Increased collection creation wait time 

### DIFF
--- a/cypress/support/collection.js
+++ b/cypress/support/collection.js
@@ -1,8 +1,8 @@
 Cypress.Commands.add("create_collection", (collectionName) => {
   cy.visit("/collection");
   cy.get('[data-testid="newItemButton"]').click();
-  cy.wait(500); //It's not the best way to wait for the dom to load, we need to find a better solution.
-  cy.get("input[name=label]").click().type(collectionName);
+  cy.wait(1000); //It's not the best way to wait for the dom to load, we need to find a better solution.
+  cy.get("input[name=label]").click().wait(1000).type(collectionName);
   cy.get('[data-testid="submitActionButton"]').click();
   cy.get("div").should("contain", "Collection created successfully!");
 });


### PR DESCRIPTION
## Summary

Sometimes the page does not completely load for adding a new collection and cypress starts to write the title. Due to this, the title was not showing correctly for the collection. This PR increases the wait time for that page to load.