### PR TITLE
fix: wa form test file

### DIFF
--- a/cypress/e2e/wa_forms/wa_form.spec.ts
+++ b/cypress/e2e/wa_forms/wa_form.spec.ts
@@ -1,3 +1,6 @@
+const FORM_DEFINITION =
+  '{"version":"7.2","screens":[{"title":"Page 1 of 2","layout":{"type":"SingleColumnLayout","children":[{"type":"Form","name":"flow_path","children":[{"type":"TextSubheading","text":"Sample form"}]}]}}]}';
+
 describe('Whatsapp Forms', () => {
   beforeEach(() => {
     cy.login();
@@ -39,8 +42,7 @@ describe('Whatsapp Forms', () => {
                   description: 'first form description',
                   status: 'DRAFT',
                   revision: {
-                    definition:
-                      '{"version":"7.2","screens":[{"title":"Page 1 of 2","layout":{"type":"SingleColumnLayout","children":[{"type":"Form","name":"flow_path","children":[{"type":"TextSubheading","text":"Sample form"}]}]}}]}',
+                    definition: FORM_DEFINITION,
                   },
                   categories: ['other'],
                 },
@@ -52,8 +54,7 @@ describe('Whatsapp Forms', () => {
                   status: 'PUBLISHED',
                   categories: ['lead_generation'],
                   revision: {
-                    definition:
-                      '{"version":"7.2","screens":[{"title":"Page 1 of 2","layout":{"type":"SingleColumnLayout","children":[{"type":"Form","name":"flow_path","children":[{"type":"TextSubheading","text":"Sample form"}]}]}}]}',
+                    definition: FORM_DEFINITION,
                   },
                 },
                 {
@@ -64,8 +65,7 @@ describe('Whatsapp Forms', () => {
                   status: 'INACTIVE',
                   categories: ['lead_generation'],
                   revision: {
-                    definition:
-                      '{"version":"7.2","screens":[{"title":"Page 1 of 2","layout":{"type":"SingleColumnLayout","children":[{"type":"Form","name":"flow_path","children":[{"type":"TextSubheading","text":"Sample form"}]}]}}]}',
+                    definition: FORM_DEFINITION,
                   },
                 },
               ],
@@ -92,8 +92,7 @@ describe('Whatsapp Forms', () => {
                   name: 'first form',
                   description: 'first form description',
                   revision: {
-                    definition:
-                      '{"version":"7.2","screens":[{"title":"Page 1 of 2","layout":{"type":"SingleColumnLayout","children":[{"type":"Form","name":"flow_path","children":[{"type":"TextSubheading","text":"Sample form"}]}]}}]}',
+                    definition: FORM_DEFINITION,
                   },
                   categories: ['survey'],
                   status: status,


### PR DESCRIPTION
<img width="1511" height="641" alt="Screenshot 2026-01-20 at 4 59 47 PM" src="https://github.com/user-attachments/assets/f43c9e3e-7033-469e-b4ff-ffbea43b1d95" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated WhatsApp form model and management flows; creation, editing, and read-only views now use the revised revision-based form data and updated controls for publish/activate/deactivate.

* **Tests**
  * Adjusted end-to-end tests to match the new form data shape, updated navigation and UI interactions, and removed legacy validation steps during creation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->