### PR TITLE
fix: set baseUrl for smoke tests

### DIFF
--- a/.github/workflows/e2e-slow.yml
+++ b/.github/workflows/e2e-slow.yml
@@ -168,11 +168,13 @@ jobs:
           timeout: 180000
 
       - name: Cypress run (filesearch slow)
+        env:
+          CYPRESS_DASHBOARD_KEY: ${{ secrets.CYPRESS_DASHBOARD_KEY }}
         run: |
           echo Create cypress.config.ts from example
           cp cypress.config.ts.example cypress.config.ts
           yarn install
-          yarn run cypress run --spec cypress/e2e/filesearch/Filesearch.spec.ts --record --key ${{ secrets.CYPRESS_DASHBOARD_KEY }}
+          yarn run cypress run --spec cypress/e2e/filesearch/Filesearch.spec.ts --record --key "$CYPRESS_DASHBOARD_KEY"
 
       - name: Upload Phoenix server logs
         if: always()

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -193,9 +193,10 @@ jobs:
           yarn run cypress run \
             --config '{"excludeSpecPattern":["cypress/e2e/filesearch/Filesearch.spec.ts","cypress/e2e/smoke.spec.ts"]}' \
             --record \
-            --key ${{ secrets.CYPRESS_DASHBOARD_KEY }}
+            --key "$CYPRESS_DASHBOARD_KEY"
 
         env:
+          CYPRESS_DASHBOARD_KEY: ${{ secrets.CYPRESS_DASHBOARD_KEY }}
           SPLIT: 2
           SPLIT_INDEX: ${{ matrix.shard }}
 

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -39,4 +39,5 @@ jobs:
           INSTATUS_COMPONENT_ID: ${{ secrets.INSTATUS_COMPONENT_ID }}
         run: |
           cp cypress.config.ts.example cypress.config.ts
-          yarn cypress run --spec cypress/e2e/smoke.spec.ts
+          yarn cypress run --spec cypress/e2e/smoke.spec.ts --record \
+            --key ${{ secrets.CYPRESS_DASHBOARD_KEY }}

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -34,10 +34,11 @@ jobs:
           CYPRESS_baseUrl: ${{ secrets.CYPRESS_SMOKE_TEST_BASE_URL }}
           CYPRESS_smoke__phone: ${{ secrets.CYPRESS_SMOKE_TEST_LOGIN_PHONE_NUMBER }}
           CYPRESS_smoke__password: ${{ secrets.CYPRESS_SMOKE_TEST_LOGIN_PASSWORD }}
+          CYPRESS_DASHBOARD_KEY: ${{ secrets.CYPRESS_DASHBOARD_KEY }}
           INSTATUS_API_KEY: ${{ secrets.INSTATUS_API_KEY }}
           INSTATUS_PAGE_ID: ${{ secrets.INSTATUS_PAGE_ID }}
           INSTATUS_COMPONENT_ID: ${{ secrets.INSTATUS_COMPONENT_ID }}
         run: |
           cp cypress.config.ts.example cypress.config.ts
           yarn cypress run --spec cypress/e2e/smoke.spec.ts --record \
-            --key ${{ secrets.CYPRESS_DASHBOARD_KEY }}
+            --key "$CYPRESS_DASHBOARD_KEY"

--- a/.github/workflows/smoke.yml
+++ b/.github/workflows/smoke.yml
@@ -31,6 +31,7 @@ jobs:
       - name: Run Cypress smoke test
         env:
           CYPRESS_smoke__baseUrl: ${{ secrets.CYPRESS_SMOKE_TEST_BASE_URL }}
+          CYPRESS_baseUrl: ${{ secrets.CYPRESS_SMOKE_TEST_BASE_URL }}
           CYPRESS_smoke__phone: ${{ secrets.CYPRESS_SMOKE_TEST_LOGIN_PHONE_NUMBER }}
           CYPRESS_smoke__password: ${{ secrets.CYPRESS_SMOKE_TEST_LOGIN_PASSWORD }}
           INSTATUS_API_KEY: ${{ secrets.INSTATUS_API_KEY }}

--- a/cypress.config.ts.example
+++ b/cypress.config.ts.example
@@ -1,6 +1,7 @@
 import { defineConfig } from 'cypress'
 import cypressSplit from 'cypress-split'
 import { reportToInstatus } from './cypress/plugins/instatus'
+import { plugins } from './cypress/plugins/index'
 
 export default defineConfig({
   allowCypressEnv: false,
@@ -30,6 +31,7 @@ export default defineConfig({
   video: false,
   e2e: {
     setupNodeEvents(on, config) {
+      config = plugins(on, config)
       cypressSplit(on, config)
 
       on('task', {

--- a/cypress/e2e/smoke.spec.ts
+++ b/cypress/e2e/smoke.spec.ts
@@ -23,10 +23,10 @@ describe('Flow smoke test', () => {
           cy.wrap(lastThree[0]).within(() => {
             cy.get('audio').should('not.exist');
             const today = new Date();
-            const dd = String(today.getDate()).padStart(2, '0');
+            const d = String(today.getDate());
             const mm = String(today.getMonth() + 1).padStart(2, '0');
             const yyyy = today.getFullYear();
-            const formattedDate = `${dd}/${mm}/${yyyy}`;
+            const formattedDate = `${d}/${mm}/${yyyy}`;
             cy.get('span').first().should('have.text', `Hello World! ${formattedDate}`);
           });
           cy.wrap(lastThree[1]).within(() => {

--- a/cypress/plugins/index.js
+++ b/cypress/plugins/index.js
@@ -1,4 +1,5 @@
 /// <reference types="cypress" />
+/* global process */
 // ***********************************************************
 // This example plugins/index.js can be used to load plugins
 //
@@ -17,5 +18,52 @@
  */
 export const plugins = (on, config) => {
   // require("@cypress/code-coverage/task")(on, config);
+  const toNestedObject = (source) =>
+    Object.entries(source || {}).reduce((acc, [key, value]) => {
+      if (!key.includes('__')) {
+        acc[key] = value;
+        return acc;
+      }
+
+      const path = key.split('__').filter(Boolean);
+      if (path.length === 0) {
+        return acc;
+      }
+
+      path.reduce((target, segment, index) => {
+        if (index === path.length - 1) {
+          target[segment] = value;
+          return target[segment];
+        }
+
+        if (
+          typeof target[segment] !== 'object' ||
+          target[segment] === null ||
+          Array.isArray(target[segment])
+        ) {
+          target[segment] = {};
+        }
+
+        return target[segment];
+      }, acc);
+
+      return acc;
+    }, {});
+
+  // Merge Cypress-provided env plus explicit CYPRESS_ vars from CI.
+  const cypressPrefixedEnv = Object.entries(process.env).reduce((acc, [key, value]) => {
+    if (!key.startsWith('CYPRESS_')) {
+      return acc;
+    }
+
+    acc[key.replace(/^CYPRESS_/, '')] = value;
+    return acc;
+  }, {});
+
+  config.env = {
+    ...toNestedObject(config.env),
+    ...toNestedObject(cypressPrefixedEnv),
+  };
+
   return config;
 };


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI test workflows now pass dashboard keys and base URL via step environment variables for safer handling.
  * Test runner imports prefixed environment variables and supports nested/structured keys when merging them into test config.
* **Tests**
  * Smoke test adjusted to use a slightly different date format to match the simulator output.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->