### PR TITLE
test(flow): drop the removed Create-from-Scratch dialog step

### DIFF
--- a/cypress/e2e/flow/Flow.spec.ts
+++ b/cypress/e2e/flow/Flow.spec.ts
@@ -108,7 +108,6 @@ describe('Flow', () => {
 
   it('should check require field validation', () => {
     cy.get('[data-testid="newItemButton"]').click();
-    cy.get('[data-testid="middle-button"]').click();
     // need some extra wait here to load formik validation library on page
     cy.wait(1000);
     cy.get('[data-testid=submitActionButton]').click({ force: true });
@@ -121,7 +120,6 @@ describe('Flow', () => {
 
   it('should create new Flow with keyword', () => {
     cy.get('[data-testid="newItemButton"]').click();
-    cy.get('[data-testid="middle-button"]').click();
     cy.get('[data-testid=outlinedInput]').eq(0).click().wait(500).type(flow);
     cy.get('[data-testid=outlinedInput]').eq(1).click().wait(500).type(randomFlowKeyword_en());
     cy.get('[data-testid="submitActionButton"]').click({ force: true });
@@ -130,7 +128,7 @@ describe('Flow', () => {
 
   it('should throw keyword already exists validation', () => {
     cy.get('[data-testid="newItemButton"]').click();
-    cy.get('[data-testid="middle-button"]').click().wait(1000);
+    cy.wait(1000);
     cy.get('input[name=name]').click().wait(500).type('Activity');
     cy.get('input[name=keywords]').click().wait(500).type('activity');
     cy.get('[data-testid="submitActionButton"]').click({ force: true });
@@ -161,7 +159,6 @@ describe('Flow', () => {
 
   it('should create new Flow in hindi', () => {
     cy.get('[data-testid="newItemButton"]').click();
-    cy.get('[data-testid="middle-button"]').click();
     cy.get('[data-testid=outlinedInput]').eq(0).click().wait(500).type(flow_hindi);
     cy.get('[data-testid=outlinedInput]').eq(1).click().wait(500).type(randomFlowKeyword_hi());
     cy.get('[data-testid="submitActionButton"]').click({ force: true });
@@ -171,7 +168,6 @@ describe('Flow', () => {
 
   it('should create new Flow without keyword', () => {
     cy.get('[data-testid="newItemButton"]').click();
-    cy.get('[data-testid="middle-button"]').click();
     cy.get('[data-testid=outlinedInput]').eq(0).click().wait(500).type(flow_with_no_keyword);
     cy.get('[data-testid="submitActionButton"]').click({ force: true });
     cy.get('div').should('contain', 'Flow created successfully!');
@@ -180,7 +176,6 @@ describe('Flow', () => {
 
   it('should check duplicate new Flow', () => {
     cy.get('[data-testid="newItemButton"]').click();
-    cy.get('[data-testid="middle-button"]').click();
     cy.get('[data-testid=outlinedInput]').eq(0).click().wait(500).type('Activity');
     cy.wait(1000);
     cy.get('[data-testid="submitActionButton"]').click({ force: true });

--- a/cypress/e2e/flow/FlowEditor.spec.ts
+++ b/cypress/e2e/flow/FlowEditor.spec.ts
@@ -17,7 +17,6 @@ describe('Flow', () => {
 
   it('should configure Flow', () => {
     cy.get('[data-testid="newItemButton"]').click();
-    cy.get('[data-testid="middle-button"]').click();
     cy.get('[data-testid=outlinedInput]').eq(0).should('be.visible').type(flowName);
 
     cy.get('[data-testid=outlinedInput]').eq(1).click().type(randomFlowKeyword_en());


### PR DESCRIPTION
## What

Remove the now-stale `[data-testid="middle-button"]` ("Create from Scratch") click from the flow-creation specs.

- `cypress/e2e/flow/Flow.spec.ts` — 6 occurrences (5 removed; the one chained with `.wait(1000)` becomes a plain `cy.wait(1000)`)
- `cypress/e2e/flow/FlowEditor.spec.ts` — 1 occurrence

## Why

`glific-frontend` removed the **"Create from Scratch / from Template"** dialog on flow creation (glific/glific-frontend#4034). The **Create** button (`newItemButton`) now navigates straight to the flow editor, so the `middle-button` no longer renders. The specs were timing out on that click:

> Timed out retrying after 8000ms: Expected to find element: `[data-testid="middle-button"]`, but never found it.

One stale click cascaded into 6 failed create-flow tests. Removing it makes the specs match the new UX.

## ⚠️ Coordination

This should merge **together with / after** glific-frontend#4034. Once #4034 is in frontend `master`:
- Branches with the new behavior (no dialog) → these updated specs pass.
- Any frontend PR still on the **old** dialog will need a rebase onto the new master, since the specs no longer dismiss that dialog.

_Scoped to the middle-button removal only. (There's a pre-existing prettier nit on line ~52 of Flow.spec.ts that is unrelated and left untouched.)_
