### PR TITLE
test: add HSM Template V2 integration tests

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -104,7 +104,6 @@ jobs:
           git clone https://github.com/glific/glific.git
           echo done. go to dir.
           cd glific
-          git checkout origin/refactor/session_file
           echo done. start dev.secret.exs config
           cd priv
           mkdir cert
@@ -153,7 +152,6 @@ jobs:
           git clone https://github.com/glific/glific-frontend.git
           echo done. go to repo dir.
           cd glific-frontend
-          git checkout feat/new_create_hsm_page
           echo copy env file.
           cp .env.example .env
           echo done.

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -104,6 +104,7 @@ jobs:
           git clone https://github.com/glific/glific.git
           echo done. go to dir.
           cd glific
+          git checkout origin/refactor/session_file
           echo done. start dev.secret.exs config
           cd priv
           mkdir cert
@@ -152,6 +153,7 @@ jobs:
           git clone https://github.com/glific/glific-frontend.git
           echo done. go to repo dir.
           cd glific-frontend
+          git checkout feat/new_create_hsm_page
           echo copy env file.
           cp .env.example .env
           echo done.

--- a/cypress/e2e/template/HSMTemplateV2.spec.ts
+++ b/cypress/e2e/template/HSMTemplateV2.spec.ts
@@ -11,9 +11,6 @@ describe('HSM Template V2', () => {
     cy.contains('Create a new HSM Template');
   };
 
-  // Stubs the createSessionTemplate mutation so submission can be asserted without
-  // needing a real, WhatsApp Business-approved backend. Every other request (login,
-  // categories, tags, languages, ...) passes through to the real backend untouched.
   const interceptCreateTemplate = (shortcode: string) => {
     cy.intercept('POST', '**/api', (req) => {
       if (req.body.operationName === 'createSessionTemplate') {
@@ -384,8 +381,7 @@ describe('HSM Template V2', () => {
       expect(input.category).to.eq('UTILITY');
       expect(input.isHsm).to.eq(true);
       expect(input.type).to.eq('TEXT');
-      expect(input.languageId).to.be.a('string');
-      expect(input.languageId).to.have.length.greaterThan(0);
+      expect(input.languageId).to.be.a('number');
       expect(input.attachmentURL).to.eq(undefined);
       expect(input.hasButtons).to.eq(undefined);
     });

--- a/cypress/e2e/template/HSMTemplateV2.spec.ts
+++ b/cypress/e2e/template/HSMTemplateV2.spec.ts
@@ -11,6 +11,48 @@ describe('HSM Template V2', () => {
     cy.contains('Create a new HSM Template');
   };
 
+  // Stubs the createSessionTemplate mutation so submission can be asserted without
+  // needing a real, WhatsApp Business-approved backend. Every other request (login,
+  // categories, tags, languages, ...) passes through to the real backend untouched.
+  const interceptCreateTemplate = (shortcode: string) => {
+    cy.intercept('POST', '**/api', (req) => {
+      if (req.body.operationName === 'createSessionTemplate') {
+        req.alias = 'createTemplate';
+        req.reply({
+          statusCode: 200,
+          body: {
+            data: {
+              createSessionTemplate: {
+                sessionTemplate: {
+                  __typename: 'SessionTemplate',
+                  id: '999999',
+                  label: null,
+                  body: sampleMessage,
+                  footer: null,
+                  isActive: true,
+                  language: { __typename: 'Language', label: 'English', id: '1' },
+                  translations: null,
+                  type: 'TEXT',
+                  MessageMedia: null,
+                  category: 'UTILITY',
+                  shortcode,
+                  example: sampleMessage,
+                  hasButtons: false,
+                  buttons: null,
+                  buttonType: null,
+                },
+                errors: null,
+                __typename: 'SessionTemplateResult',
+              },
+            },
+          },
+        });
+      } else {
+        req.continue();
+      }
+    });
+  };
+
   beforeEach(function () {
     cy.login();
     cy.visit('/template-v2');
@@ -317,6 +359,66 @@ describe('HSM Template V2', () => {
     cy.get('[data-testid="AutocompleteInput"] input').eq(1).click().type(newTag);
     cy.contains(`Create "${newTag}"`).click({ force: true });
     cy.get('[data-testid="AutocompleteInput"] input').eq(1).should('have.value', newTag);
+  });
+
+  // ---------- Create page: Form submission ----------
+
+  it('should submit a text-only template with the correct payload', () => {
+    const shortcode = 'cy_submit_text_' + Date.now();
+    interceptCreateTemplate(shortcode);
+    openCreatePage();
+
+    cy.get('input[name="newShortcode"]').click().type(shortcode);
+    cy.contains('button', 'Utility').click();
+    cy.get('[data-testid="editor-body"]').click().type(sampleMessage).blur({ force: true });
+    cy.get('[data-testid="beneficiaryName"]').click();
+    cy.get('html').click();
+
+    cy.get('[data-testid="submitActionButton"]').click();
+
+    cy.wait('@createTemplate').then((interception) => {
+      const input = interception.request.body.variables.input;
+      expect(input.shortcode).to.eq(shortcode);
+      expect(input.body).to.eq(sampleMessage);
+      expect(input.example).to.eq(sampleMessage);
+      expect(input.category).to.eq('UTILITY');
+      expect(input.isHsm).to.eq(true);
+      expect(input.type).to.eq('TEXT');
+      expect(input.languageId).to.be.a('string');
+      expect(input.languageId).to.have.length.greaterThan(0);
+      expect(input.attachmentURL).to.eq(undefined);
+      expect(input.hasButtons).to.eq(undefined);
+    });
+    cy.contains('HSM Template created successfully!');
+  });
+
+  it('should submit a template with a Quick Reply button and the correct payload', () => {
+    const shortcode = 'cy_submit_qr_' + Date.now();
+    interceptCreateTemplate(shortcode);
+    openCreatePage();
+
+    cy.get('input[name="newShortcode"]').click().type(shortcode);
+    cy.contains('button', 'Utility').click();
+    cy.get('[data-testid="editor-body"]').click().type(sampleMessage).blur({ force: true });
+
+    cy.contains('button', 'Quick Reply').click();
+    cy.get('input[placeholder="e.g., Yes, No, More Info"]').type('Yes');
+
+    cy.get('[data-testid="beneficiaryName"]').click();
+    cy.get('html').click();
+
+    cy.get('[data-testid="submitActionButton"]').click();
+
+    cy.wait('@createTemplate').then((interception) => {
+      const input = interception.request.body.variables.input;
+      expect(input.shortcode).to.eq(shortcode);
+      expect(input.category).to.eq('UTILITY');
+      expect(input.isHsm).to.eq(true);
+      expect(input.hasButtons).to.eq(true);
+      expect(input.buttonType).to.eq('QUICK_REPLY');
+      expect(JSON.parse(input.buttons)).to.deep.eq([{ type: 'QUICK_REPLY', text: 'Yes' }]);
+    });
+    cy.contains('HSM Template created successfully!');
   });
 
   // ---------- Create page: Navigation ----------

--- a/cypress/e2e/template/HSMTemplateV2.spec.ts
+++ b/cypress/e2e/template/HSMTemplateV2.spec.ts
@@ -1,10 +1,15 @@
 describe('HSM Template V2', () => {
-  const hsmTemplateName = 'sample_hsm_v2_' + +new Date();
+  const hsmTemplateName = 'sample_hsm_v2_' + Date.now();
   const sampleMessage = 'This is a sample message for HSMV2';
   const imageURL = 'https://www.buildquickbots.com/whatsapp/media/sample/jpg/sample01.jpg';
   const documentURL = 'https://www.buildquickbots.com/whatsapp/media/sample/pdf/sample01.pdf';
   const videoURL =
     'http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/WeAreGoingOnBullrun.mp4';
+
+  const openCreatePage = () => {
+    cy.get('[data-testid="newItemButton"]').click();
+    cy.contains('Create a new HSM Template');
+  };
 
   beforeEach(function () {
     cy.login();
@@ -21,6 +26,7 @@ describe('HSM Template V2', () => {
     cy.get('[data-testid="dropdown-template"]').click();
     cy.get('[data-testid="template-item"]').contains('Pending').click({ force: true });
     cy.get('html').click();
+    cy.get('[data-testid="dropdown-template"]').should('contain', 'Pending');
   });
 
   it('should filter templates by category', () => {
@@ -30,55 +36,50 @@ describe('HSM Template V2', () => {
   });
 
   it('should navigate to the create page on clicking Create', () => {
-    cy.get('[data-testid="newItemButton"]').click();
+    openCreatePage();
     cy.location('pathname').should('eq', '/template-v2/add');
-    cy.contains('Create a new HSM Template');
   });
 
   it('should check validation', () => {
-    cy.get('[data-testid="newItemButton"]').click();
-    cy.wait(1000);
+    openCreatePage();
     cy.get('[data-testid="submitActionButton"]').click();
     cy.contains('Element name is required.');
     cy.contains('Message is required.');
   });
 
   it('should select a language', () => {
-    cy.get('[data-testid="newItemButton"]').click();
-    cy.wait(1000);
+    openCreatePage();
     cy.get('[data-testid="AutocompleteInput"] input').eq(0).click().clear().type('Hindi');
     cy.contains('Hindi').click({ force: true });
     cy.get('[data-testid="AutocompleteInput"] input').eq(0).should('have.value', 'Hindi');
   });
 
   it('should type the element name', () => {
-    cy.get('[data-testid="newItemButton"]').click();
-    cy.wait(1000);
+    openCreatePage();
     cy.get('input[name="newShortcode"]').click().type(hsmTemplateName);
     cy.get('input[name="newShortcode"]').should('have.value', hsmTemplateName);
   });
 
   it('should select a category', () => {
-    cy.get('[data-testid="newItemButton"]').click();
-    cy.wait(1000);
+    openCreatePage();
     cy.contains('button', 'Utility').click();
     cy.contains('button', 'Marketing').should('be.visible').click();
   });
 
   it('should show typed sample message in simulator', () => {
-    cy.get('[data-testid="newItemButton"]').click();
-    cy.wait(1000);
+    openCreatePage();
 
     cy.get('[data-testid="editor-body"]').click().type(sampleMessage).blur({ force: true });
     cy.get('[data-testid="beneficiaryName"]').click();
     cy.get('html').click();
-    cy.wait(2000);
-    cy.get('[data-testid="simulatedMessages"] > div > div').should('contain', sampleMessage);
+    cy.get('[data-testid="simulatedMessages"] > div > div', { timeout: 10000 }).should(
+      'contain',
+      sampleMessage
+    );
   });
 
   it('should apply bold formatting to the message', () => {
-    cy.get('[data-testid="newItemButton"]').click();
-    cy.wait(1000);
+    openCreatePage();
 
     cy.get('[data-testid="editor-body"]').click().type(sampleMessage);
     cy.get('[data-testid="bold-icon"]').click();
@@ -88,18 +89,17 @@ describe('HSM Template V2', () => {
   });
 
   it('should add a variable to the message and set its value', () => {
-    cy.get('[data-testid="newItemButton"]').click();
-    cy.wait(1000);
+    openCreatePage();
 
     cy.get('[data-testid="editor-body"]').click().type(sampleMessage);
     cy.contains('Add Variable').click();
     cy.get('[data-testid="variable"]').should('have.length', 1);
     cy.get('input[placeholder="Define value"]').type('User');
+    cy.get('input[placeholder="Define value"]').should('have.value', 'User');
   });
 
   it('should add a footer to the template', () => {
-    cy.get('[data-testid="newItemButton"]').click();
-    cy.wait(1000);
+    openCreatePage();
     cy.get('input[name="footer"]').click().type('This is a footer');
     cy.get('input[name="footer"]').should('have.value', 'This is a footer');
   });
@@ -107,8 +107,7 @@ describe('HSM Template V2', () => {
   // ---------- Create page: Interactive Buttons -> Quick Reply ----------
 
   it('should select Quick Reply and show the live character count', () => {
-    cy.get('[data-testid="newItemButton"]').click();
-    cy.wait(1000);
+    openCreatePage();
 
     cy.contains('button', 'Quick Reply').click();
     cy.contains('Maximum 10 quick reply buttons allowed per template');
@@ -117,8 +116,7 @@ describe('HSM Template V2', () => {
   });
 
   it('should add and remove multiple quick reply buttons', () => {
-    cy.get('[data-testid="newItemButton"]').click();
-    cy.wait(1000);
+    openCreatePage();
 
     cy.contains('button', 'Quick Reply').click();
     cy.get('[data-testid="addButton"]').click();
@@ -130,8 +128,7 @@ describe('HSM Template V2', () => {
   });
 
   it('should clear the interactive button type selection', () => {
-    cy.get('[data-testid="newItemButton"]').click();
-    cy.wait(1000);
+    openCreatePage();
 
     cy.contains('button', 'Quick Reply').click();
     cy.contains('Clear button selection').click();
@@ -141,18 +138,18 @@ describe('HSM Template V2', () => {
   // ---------- Create page: Interactive Buttons -> Call to Action ----------
 
   it('should add a Phone number Call to Action button', () => {
-    cy.get('[data-testid="newItemButton"]').click();
-    cy.wait(1000);
+    openCreatePage();
 
     cy.contains('button', 'Call to Action').click();
     cy.contains('button', 'Phone number').click();
     cy.get('input[placeholder="e.g., Call Us"]').type('Call me');
     cy.get('input[placeholder="+91 98765 43210"]').type('9876543210');
+    cy.get('input[placeholder="e.g., Call Us"]').should('have.value', 'Call me');
+    cy.get('input[placeholder="+91 98765 43210"]').should('have.value', '9876543210');
   });
 
   it('should disable the Phone number chip once its limit is reached', () => {
-    cy.get('[data-testid="newItemButton"]').click();
-    cy.wait(1000);
+    openCreatePage();
 
     cy.contains('button', 'Call to Action').click();
     cy.contains('button', 'Phone number').click();
@@ -160,8 +157,7 @@ describe('HSM Template V2', () => {
   });
 
   it('should reveal the Advanced section with Static and Dynamic URL options for a URL button', () => {
-    cy.get('[data-testid="newItemButton"]').click();
-    cy.wait(1000);
+    openCreatePage();
 
     cy.contains('button', 'Call to Action').click();
     cy.contains('button', 'URL').click();
@@ -173,8 +169,7 @@ describe('HSM Template V2', () => {
   });
 
   it('should show the Sample Suffix field when Dynamic URL is selected', () => {
-    cy.get('[data-testid="newItemButton"]').click();
-    cy.wait(1000);
+    openCreatePage();
 
     cy.contains('button', 'Call to Action').click();
     cy.contains('button', 'URL').click();
@@ -182,11 +177,11 @@ describe('HSM Template V2', () => {
     cy.contains('Dynamic URL').click();
 
     cy.get('input[placeholder="Sample Suffix"]').should('be.visible').type('promo');
+    cy.get('input[placeholder="Sample Suffix"]').should('have.value', 'promo');
   });
 
   it('should add and remove multiple Call to Action buttons', () => {
-    cy.get('[data-testid="newItemButton"]').click();
-    cy.wait(1000);
+    openCreatePage();
 
     cy.contains('button', 'Call to Action').click();
     cy.contains('button', 'Phone number').click();
@@ -203,56 +198,59 @@ describe('HSM Template V2', () => {
   // ---------- Create page: Interactive Buttons -> WhatsApp Form ----------
 
   it('should show the WhatsApp Form fields', () => {
-    cy.get('[data-testid="newItemButton"]').click();
-    cy.wait(1000);
+    openCreatePage();
 
     cy.contains('button', 'WhatsApp Form').click();
     cy.contains('Select Form*');
     cy.contains('Screen Name*');
     cy.contains('Button Title*');
     cy.get('input[placeholder="e.g., Fill Form"]').type('Continue');
+    cy.get('input[placeholder="e.g., Fill Form"]').should('have.value', 'Continue');
   });
 
   // ---------- Create page: Media Attachment ----------
 
   it('should show attached image with the sample message as caption', () => {
-    cy.get('[data-testid="newItemButton"]').click();
-    cy.wait(1000);
+    openCreatePage();
 
     cy.contains('button', 'Image').click();
-    cy.get('input[name="attachmentURL"]').click().type(imageURL).wait(500);
+    cy.get('input[name="attachmentURL"]').click().type(imageURL);
 
     cy.get('[data-testid="editor-body"]').click().type(sampleMessage).blur({ force: true });
     cy.get('[data-testid="beneficiaryName"]').click();
     cy.get('html').click();
-    cy.wait(5000);
 
-    cy.get('[data-testid=imageMessage] > img').should('have.attr', 'src', imageURL);
+    cy.get('[data-testid=imageMessage] > img', { timeout: 10000 }).should(
+      'have.attr',
+      'src',
+      imageURL
+    );
     cy.get('[data-testid="simulatedMessages"] > div > div').should('contain', sampleMessage);
   });
 
   it('should show attached document with the sample message as caption', () => {
-    cy.get('[data-testid="newItemButton"]').click();
-    cy.wait(1000);
+    openCreatePage();
 
     cy.contains('button', 'Document').click();
-    cy.get('input[name="attachmentURL"]').click().type(documentURL).wait(500);
+    cy.get('input[name="attachmentURL"]').click().type(documentURL);
 
     cy.get('[data-testid="editor-body"]').click().type(sampleMessage).blur({ force: true });
     cy.get('[data-testid="beneficiaryName"]').click();
     cy.get('html').click();
-    cy.wait(5000);
 
-    cy.get('[data-testid=documentMessage] > a').should('have.attr', 'href', documentURL);
+    cy.get('[data-testid=documentMessage] > a', { timeout: 10000 }).should(
+      'have.attr',
+      'href',
+      documentURL
+    );
     cy.get('[data-testid="simulatedMessages"] > div > div').should('contain', sampleMessage);
   });
 
   it('should show attached video with the sample message as caption', () => {
-    cy.get('[data-testid="newItemButton"]').click();
-    cy.wait(1000);
+    openCreatePage();
 
     cy.contains('button', 'Video').click();
-    cy.get('input[name="attachmentURL"]').click().type(videoURL).wait(500);
+    cy.get('input[name="attachmentURL"]').click().type(videoURL);
 
     cy.get('[data-testid="editor-body"]')
       .click()
@@ -260,15 +258,17 @@ describe('HSM Template V2', () => {
       .blur({ force: true });
     cy.get('[data-testid="beneficiaryName"]').click();
     cy.get('html').click();
-    cy.wait(5000);
 
-    cy.get('[data-testid=videoMessage]');
+    cy.get('[data-testid=videoMessage] video', { timeout: 10000 }).should(
+      'have.attr',
+      'src',
+      videoURL
+    );
     cy.get('[data-testid="simulatedMessages"] > div > div').should('contain', sampleMessage);
   });
 
   it('should offer both Provide URL and Upload File options for an attachment type', () => {
-    cy.get('[data-testid="newItemButton"]').click();
-    cy.wait(1000);
+    openCreatePage();
 
     cy.contains('button', 'Document').click();
     cy.contains('How would you like to provide the attachment?');
@@ -277,8 +277,7 @@ describe('HSM Template V2', () => {
   });
 
   it('should show a warning when uploading a file without Google Cloud Storage enabled', () => {
-    cy.get('[data-testid="newItemButton"]').click();
-    cy.wait(1000);
+    openCreatePage();
 
     cy.contains('button', 'Image').click();
     cy.contains('button', 'Upload File').click();
@@ -289,8 +288,7 @@ describe('HSM Template V2', () => {
   });
 
   it('should clear the attachment type selection', () => {
-    cy.get('[data-testid="newItemButton"]').click();
-    cy.wait(1000);
+    openCreatePage();
 
     cy.contains('button', 'Image').click();
     cy.contains('Clear attachment selection').should('be.visible');
@@ -301,8 +299,7 @@ describe('HSM Template V2', () => {
   });
 
   it('should switch attachment type from Image to Document', () => {
-    cy.get('[data-testid="newItemButton"]').click();
-    cy.wait(1000);
+    openCreatePage();
 
     cy.contains('button', 'Image').click();
     cy.get('input[name="attachmentURL"]').click().type(imageURL);
@@ -314,8 +311,7 @@ describe('HSM Template V2', () => {
   // ---------- Create page: Organization & Tags ----------
 
   it('should create a new tag', () => {
-    cy.get('[data-testid="newItemButton"]').click();
-    cy.wait(1000);
+    openCreatePage();
 
     const newTag = 'cy_tag_' + Date.now();
     cy.get('[data-testid="AutocompleteInput"] input').eq(1).click().type(newTag);
@@ -323,16 +319,16 @@ describe('HSM Template V2', () => {
     cy.get('[data-testid="AutocompleteInput"] input').eq(1).should('have.value', newTag);
   });
 
+  // ---------- Create page: Navigation ----------
+
   it('should navigate back to the list on clicking cancel', () => {
-    cy.get('[data-testid="newItemButton"]').click();
-    cy.wait(1000);
+    openCreatePage();
     cy.get('[data-testid="cancelActionButton"]').click();
     cy.location('pathname').should('eq', '/template-v2');
   });
 
   it('should navigate back to the list on clicking the back icon', () => {
-    cy.get('[data-testid="newItemButton"]').click();
-    cy.wait(1000);
+    openCreatePage();
     cy.get('[data-testid="back-button"]').click();
     cy.location('pathname').should('eq', '/template-v2');
   });

--- a/cypress/e2e/template/HSMTemplateV2.spec.ts
+++ b/cypress/e2e/template/HSMTemplateV2.spec.ts
@@ -1,0 +1,339 @@
+describe('HSM Template V2', () => {
+  const hsmTemplateName = 'sample_hsm_v2_' + +new Date();
+  const sampleMessage = 'This is a sample message for HSMV2';
+  const imageURL = 'https://www.buildquickbots.com/whatsapp/media/sample/jpg/sample01.jpg';
+  const documentURL = 'https://www.buildquickbots.com/whatsapp/media/sample/pdf/sample01.pdf';
+  const videoURL =
+    'http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/WeAreGoingOnBullrun.mp4';
+
+  beforeEach(function () {
+    cy.login();
+    cy.visit('/template-v2');
+  });
+
+  it('should load HSM template list', () => {
+    cy.get('[data-testid="listHeader"]').should('contain', 'HSM Templates');
+    cy.get('[data-testid="newItemButton"]').should('be.visible');
+    cy.get('[data-testid="syncHsm"]').should('be.visible');
+  });
+
+  it('should filter templates by status', () => {
+    cy.get('[data-testid="dropdown-template"]').click();
+    cy.get('[data-testid="template-item"]').contains('Pending').click({ force: true });
+    cy.get('html').click();
+  });
+
+  it('should filter templates by category', () => {
+    cy.get('[data-testid="categoryFilter"]').click();
+    cy.contains('li', 'Utility').click({ force: true });
+    cy.get('[data-testid="categoryFilter"]').should('contain', 'Utility');
+  });
+
+  it('should navigate to the create page on clicking Create', () => {
+    cy.get('[data-testid="newItemButton"]').click();
+    cy.location('pathname').should('eq', '/template-v2/add');
+    cy.contains('Create a new HSM Template');
+  });
+
+  it('should check validation', () => {
+    cy.get('[data-testid="newItemButton"]').click();
+    cy.wait(1000);
+    cy.get('[data-testid="submitActionButton"]').click();
+    cy.contains('Element name is required.');
+    cy.contains('Message is required.');
+  });
+
+  it('should select a language', () => {
+    cy.get('[data-testid="newItemButton"]').click();
+    cy.wait(1000);
+    cy.get('[data-testid="AutocompleteInput"] input').eq(0).click().clear().type('Hindi');
+    cy.contains('Hindi').click({ force: true });
+    cy.get('[data-testid="AutocompleteInput"] input').eq(0).should('have.value', 'Hindi');
+  });
+
+  it('should type the element name', () => {
+    cy.get('[data-testid="newItemButton"]').click();
+    cy.wait(1000);
+    cy.get('input[name="newShortcode"]').click().type(hsmTemplateName);
+    cy.get('input[name="newShortcode"]').should('have.value', hsmTemplateName);
+  });
+
+  it('should select a category', () => {
+    cy.get('[data-testid="newItemButton"]').click();
+    cy.wait(1000);
+    cy.contains('button', 'Utility').click();
+    cy.contains('button', 'Marketing').should('be.visible').click();
+  });
+
+  it('should show typed sample message in simulator', () => {
+    cy.get('[data-testid="newItemButton"]').click();
+    cy.wait(1000);
+
+    cy.get('[data-testid="editor-body"]').click().type(sampleMessage).blur({ force: true });
+    cy.get('[data-testid="beneficiaryName"]').click();
+    cy.get('html').click();
+    cy.wait(2000);
+    cy.get('[data-testid="simulatedMessages"] > div > div').should('contain', sampleMessage);
+  });
+
+  it('should apply bold formatting to the message', () => {
+    cy.get('[data-testid="newItemButton"]').click();
+    cy.wait(1000);
+
+    cy.get('[data-testid="editor-body"]').click().type(sampleMessage);
+    cy.get('[data-testid="bold-icon"]').click();
+    cy.get('[data-testid="italic-icon"]').should('be.visible');
+    cy.get('[data-testid="strikethrough-icon"]').should('be.visible');
+    cy.get('[data-testid="editor-body"]').should('contain', '**');
+  });
+
+  it('should add a variable to the message and set its value', () => {
+    cy.get('[data-testid="newItemButton"]').click();
+    cy.wait(1000);
+
+    cy.get('[data-testid="editor-body"]').click().type(sampleMessage);
+    cy.contains('Add Variable').click();
+    cy.get('[data-testid="variable"]').should('have.length', 1);
+    cy.get('input[placeholder="Define value"]').type('User');
+  });
+
+  it('should add a footer to the template', () => {
+    cy.get('[data-testid="newItemButton"]').click();
+    cy.wait(1000);
+    cy.get('input[name="footer"]').click().type('This is a footer');
+    cy.get('input[name="footer"]').should('have.value', 'This is a footer');
+  });
+
+  // ---------- Create page: Interactive Buttons -> Quick Reply ----------
+
+  it('should select Quick Reply and show the live character count', () => {
+    cy.get('[data-testid="newItemButton"]').click();
+    cy.wait(1000);
+
+    cy.contains('button', 'Quick Reply').click();
+    cy.contains('Maximum 10 quick reply buttons allowed per template');
+    cy.get('input[placeholder="e.g., Yes, No, More Info"]').type('Yes');
+    cy.contains('3 / 20');
+  });
+
+  it('should add and remove multiple quick reply buttons', () => {
+    cy.get('[data-testid="newItemButton"]').click();
+    cy.wait(1000);
+
+    cy.contains('button', 'Quick Reply').click();
+    cy.get('[data-testid="addButton"]').click();
+    cy.get('input[placeholder="e.g., Yes, No, More Info"]').should('have.length', 2);
+    cy.get('[data-testid="delete-icon"]').should('have.length', 2);
+
+    cy.get('[data-testid="delete-icon"]').eq(1).click();
+    cy.get('input[placeholder="e.g., Yes, No, More Info"]').should('have.length', 1);
+  });
+
+  it('should clear the interactive button type selection', () => {
+    cy.get('[data-testid="newItemButton"]').click();
+    cy.wait(1000);
+
+    cy.contains('button', 'Quick Reply').click();
+    cy.contains('Clear button selection').click();
+    cy.contains('Clear button selection').should('not.exist');
+  });
+
+  // ---------- Create page: Interactive Buttons -> Call to Action ----------
+
+  it('should add a Phone number Call to Action button', () => {
+    cy.get('[data-testid="newItemButton"]').click();
+    cy.wait(1000);
+
+    cy.contains('button', 'Call to Action').click();
+    cy.contains('button', 'Phone number').click();
+    cy.get('input[placeholder="e.g., Call Us"]').type('Call me');
+    cy.get('input[placeholder="+91 98765 43210"]').type('9876543210');
+  });
+
+  it('should disable the Phone number chip once its limit is reached', () => {
+    cy.get('[data-testid="newItemButton"]').click();
+    cy.wait(1000);
+
+    cy.contains('button', 'Call to Action').click();
+    cy.contains('button', 'Phone number').click();
+    cy.contains('button', 'Phone number').should('be.disabled');
+  });
+
+  it('should reveal the Advanced section with Static and Dynamic URL options for a URL button', () => {
+    cy.get('[data-testid="newItemButton"]').click();
+    cy.wait(1000);
+
+    cy.contains('button', 'Call to Action').click();
+    cy.contains('button', 'URL').click();
+    cy.contains('Static URL').should('not.exist');
+
+    cy.contains('Advanced').click();
+    cy.contains('Static URL').should('be.visible');
+    cy.contains('Dynamic URL').should('be.visible');
+  });
+
+  it('should show the Sample Suffix field when Dynamic URL is selected', () => {
+    cy.get('[data-testid="newItemButton"]').click();
+    cy.wait(1000);
+
+    cy.contains('button', 'Call to Action').click();
+    cy.contains('button', 'URL').click();
+    cy.contains('Advanced').click();
+    cy.contains('Dynamic URL').click();
+
+    cy.get('input[placeholder="Sample Suffix"]').should('be.visible').type('promo');
+  });
+
+  it('should add and remove multiple Call to Action buttons', () => {
+    cy.get('[data-testid="newItemButton"]').click();
+    cy.wait(1000);
+
+    cy.contains('button', 'Call to Action').click();
+    cy.contains('button', 'Phone number').click();
+    cy.get('input[placeholder="e.g., Call Us"]').type('Call me');
+    cy.get('input[placeholder="+91 98765 43210"]').type('9876543210');
+
+    cy.get('[data-testid="addButton"]').click();
+    cy.get('[data-testid="delete-icon"]').should('have.length', 2);
+
+    cy.get('[data-testid="delete-icon"]').eq(1).click();
+    cy.get('[data-testid="delete-icon"]').should('have.length', 0);
+  });
+
+  // ---------- Create page: Interactive Buttons -> WhatsApp Form ----------
+
+  it('should show the WhatsApp Form fields', () => {
+    cy.get('[data-testid="newItemButton"]').click();
+    cy.wait(1000);
+
+    cy.contains('button', 'WhatsApp Form').click();
+    cy.contains('Select Form*');
+    cy.contains('Screen Name*');
+    cy.contains('Button Title*');
+    cy.get('input[placeholder="e.g., Fill Form"]').type('Continue');
+  });
+
+  // ---------- Create page: Media Attachment ----------
+
+  it('should show attached image with the sample message as caption', () => {
+    cy.get('[data-testid="newItemButton"]').click();
+    cy.wait(1000);
+
+    cy.contains('button', 'Image').click();
+    cy.get('input[name="attachmentURL"]').click().type(imageURL).wait(500);
+
+    cy.get('[data-testid="editor-body"]').click().type(sampleMessage).blur({ force: true });
+    cy.get('[data-testid="beneficiaryName"]').click();
+    cy.get('html').click();
+    cy.wait(5000);
+
+    cy.get('[data-testid=imageMessage] > img').should('have.attr', 'src', imageURL);
+    cy.get('[data-testid="simulatedMessages"] > div > div').should('contain', sampleMessage);
+  });
+
+  it('should show attached document with the sample message as caption', () => {
+    cy.get('[data-testid="newItemButton"]').click();
+    cy.wait(1000);
+
+    cy.contains('button', 'Document').click();
+    cy.get('input[name="attachmentURL"]').click().type(documentURL).wait(500);
+
+    cy.get('[data-testid="editor-body"]').click().type(sampleMessage).blur({ force: true });
+    cy.get('[data-testid="beneficiaryName"]').click();
+    cy.get('html').click();
+    cy.wait(5000);
+
+    cy.get('[data-testid=documentMessage] > a').should('have.attr', 'href', documentURL);
+    cy.get('[data-testid="simulatedMessages"] > div > div').should('contain', sampleMessage);
+  });
+
+  it('should show attached video with the sample message as caption', () => {
+    cy.get('[data-testid="newItemButton"]').click();
+    cy.wait(1000);
+
+    cy.contains('button', 'Video').click();
+    cy.get('input[name="attachmentURL"]').click().type(videoURL).wait(500);
+
+    cy.get('[data-testid="editor-body"]')
+      .click()
+      .type(sampleMessage, { delay: 80 })
+      .blur({ force: true });
+    cy.get('[data-testid="beneficiaryName"]').click();
+    cy.get('html').click();
+    cy.wait(5000);
+
+    cy.get('[data-testid=videoMessage]');
+    cy.get('[data-testid="simulatedMessages"] > div > div').should('contain', sampleMessage);
+  });
+
+  it('should offer both Provide URL and Upload File options for an attachment type', () => {
+    cy.get('[data-testid="newItemButton"]').click();
+    cy.wait(1000);
+
+    cy.contains('button', 'Document').click();
+    cy.contains('How would you like to provide the attachment?');
+    cy.contains('button', 'Provide URL').should('be.visible');
+    cy.contains('button', 'Upload File').should('be.visible');
+  });
+
+  it('should show a warning when uploading a file without Google Cloud Storage enabled', () => {
+    cy.get('[data-testid="newItemButton"]').click();
+    cy.wait(1000);
+
+    cy.contains('button', 'Image').click();
+    cy.contains('button', 'Upload File').click();
+    cy.contains(
+      'File upload is not available for your organization. Please use "Provide URL" instead, or ask your admin to enable Google Cloud Storage.'
+    );
+    cy.contains('Click to upload or drag and drop').should('not.exist');
+  });
+
+  it('should clear the attachment type selection', () => {
+    cy.get('[data-testid="newItemButton"]').click();
+    cy.wait(1000);
+
+    cy.contains('button', 'Image').click();
+    cy.contains('Clear attachment selection').should('be.visible');
+
+    cy.contains('Clear attachment selection').click();
+    cy.contains('Clear attachment selection').should('not.exist');
+    cy.get('input[name="attachmentURL"]').should('not.exist');
+  });
+
+  it('should switch attachment type from Image to Document', () => {
+    cy.get('[data-testid="newItemButton"]').click();
+    cy.wait(1000);
+
+    cy.contains('button', 'Image').click();
+    cy.get('input[name="attachmentURL"]').click().type(imageURL);
+
+    cy.contains('button', 'Document').click();
+    cy.get('input[name="attachmentURL"]').should('have.value', '');
+  });
+
+  // ---------- Create page: Organization & Tags ----------
+
+  it('should create a new tag', () => {
+    cy.get('[data-testid="newItemButton"]').click();
+    cy.wait(1000);
+
+    const newTag = 'cy_tag_' + Date.now();
+    cy.get('[data-testid="AutocompleteInput"] input').eq(1).click().type(newTag);
+    cy.contains(`Create "${newTag}"`).click({ force: true });
+    cy.get('[data-testid="AutocompleteInput"] input').eq(1).should('have.value', newTag);
+  });
+
+  it('should navigate back to the list on clicking cancel', () => {
+    cy.get('[data-testid="newItemButton"]').click();
+    cy.wait(1000);
+    cy.get('[data-testid="cancelActionButton"]').click();
+    cy.location('pathname').should('eq', '/template-v2');
+  });
+
+  it('should navigate back to the list on clicking the back icon', () => {
+    cy.get('[data-testid="newItemButton"]').click();
+    cy.wait(1000);
+    cy.get('[data-testid="back-button"]').click();
+    cy.location('pathname').should('eq', '/template-v2');
+  });
+});

--- a/cypress/e2e/template/HSMTemplateV2.spec.ts
+++ b/cypress/e2e/template/HSMTemplateV2.spec.ts
@@ -432,3 +432,298 @@ describe('HSM Template V2', () => {
     cy.location('pathname').should('eq', '/template-v2');
   });
 });
+
+describe('HSM Template V2 - View & Add Language', () => {
+  const familyShortcode = 'cy_hsm_family_' + Date.now();
+  const anchorId = '910001';
+  const hindiId = '910002';
+  const pendingId = '910003';
+  const failedId = '910004';
+  const newVariantId = '910005';
+
+  // This dev org only has English + Hindi active — real, fetched once below —
+  // so the fixtures below deliberately reuse those two labels across extra
+  // status/id slots instead of assuming a richer language catalog exists.
+  let realLanguages: Array<{ id: string; label: string; locale: string }> = [];
+
+  const langByLabel = (label: string) => {
+    const found = realLanguages.find((language) => language.label === label);
+    if (!found) {
+      throw new Error(`Expected an active "${label}" language in this org's language list`);
+    }
+    return found;
+  };
+
+  before(() => {
+    // Reuse cy.login() (same as every beforeEach in this file) rather than
+    // re-POSTing to /v1/session ourselves — it already stores the session,
+    // access_token included, under the glific_session localStorage key.
+    cy.login();
+    cy.window()
+      .then((win) => JSON.parse(win.localStorage.getItem('glific_session') || '{}').access_token)
+      .then((accessToken) => {
+        cy.request({
+          method: 'POST',
+          url: Cypress.expose('backendUrl'),
+          headers: { authorization: accessToken },
+          body: {
+            query: `query { currentUser { user { organization { activeLanguages { id label locale } } } } }`,
+          },
+        }).then((languagesResponse) => {
+          realLanguages = languagesResponse.body.data.currentUser.user.organization.activeLanguages;
+        });
+      });
+  });
+
+  const baseVariant = (overrides: Record<string, any> = {}) => ({
+    __typename: 'SessionTemplate',
+    bspId: null,
+    label: 'Cypress Welcome',
+    body: 'Hi {{1}}, welcome!',
+    footer: null,
+    shortcode: familyShortcode,
+    category: 'UTILITY',
+    isReserved: false,
+    status: 'APPROVED',
+    reason: null,
+    isHsm: true,
+    isActive: true,
+    updatedAt: '2024-01-15T10:00:00Z',
+    numberParameters: 1,
+    translations: null,
+    type: 'TEXT',
+    quality: 'HIGH',
+    language: { __typename: 'Language', ...langByLabel('English') },
+    tag: null,
+    MessageMedia: null,
+    ...overrides,
+  });
+
+  let family: Array<Record<string, any>> = [];
+
+  // `mode: 'full'` builds all four status buckets (for the direct view page's
+  // tab-grouping tests), reusing English/Hindi across the extra Pending/Failed
+  // slots since this org only has those two languages active. `includeSibling:
+  // false` leaves the anchor as the family's only member, so Hindi stays free
+  // for the "add a language" tests to pick; `includeSibling: true` (default)
+  // adds a Hindi sibling, for tests that need something to view/delete.
+  const interceptFamily = (options: { mode?: 'full'; includeSibling?: boolean } = {}) => {
+    const { mode, includeSibling = true } = options;
+    const englishVariant = baseVariant({ id: anchorId });
+    const hindiVariant = baseVariant({
+      id: hindiId,
+      body: 'Namaste {{1}}, swagat hai!',
+      language: { __typename: 'Language', ...langByLabel('Hindi') },
+    });
+    if (mode === 'full') {
+      const pendingVariant = baseVariant({
+        id: pendingId,
+        status: 'PENDING',
+        body: 'Namaste {{1}}, swagat hai!',
+        language: { __typename: 'Language', ...langByLabel('Hindi') },
+      });
+      const failedVariant = baseVariant({
+        id: failedId,
+        status: 'FAILED',
+        body: 'Hi {{1}}, welcome!',
+        language: { __typename: 'Language', ...langByLabel('English') },
+      });
+      family = [englishVariant, hindiVariant, pendingVariant, failedVariant];
+    } else {
+      family = includeSibling ? [englishVariant, hindiVariant] : [englishVariant];
+    }
+
+    cy.intercept('POST', '**/api', (req) => {
+      const op = req.body.operationName;
+      if (op === 'sessionTemplates') {
+        req.alias = 'sessionTemplatesQuery';
+        req.reply({ statusCode: 200, body: { data: { sessionTemplates: family } } });
+      } else if (op === 'getsessionTemplate') {
+        // Return the specific variant that was asked for (falling back to the
+        // anchor) so the Apollo cache write for this id never clobbers another
+        // entity's normalized record and re-triggers unrelated query watchers.
+        const requestedId = req.body.variables?.id;
+        const entity = family.find((variant) => variant.id === requestedId) || englishVariant;
+        req.alias = 'getAnchorTemplate';
+        req.reply({
+          statusCode: 200,
+          body: {
+            data: {
+              sessionTemplate: {
+                __typename: 'SessionTemplateResult',
+                sessionTemplate: {
+                  ...entity,
+                  example: entity.body,
+                  hasButtons: false,
+                  buttons: null,
+                  buttonType: null,
+                },
+              },
+            },
+          },
+        });
+      } else if (op === 'deleteSessionTemplate') {
+        const deletedId = req.body.variables?.id;
+        family = family.filter((variant) => variant.id !== deletedId);
+        req.alias = 'deleteVariant';
+        req.reply({ statusCode: 200, body: { data: { deleteSessionTemplate: { errors: null } } } });
+      } else if (op === 'createSessionTemplate') {
+        const created = baseVariant({
+          id: newVariantId,
+          status: 'PENDING',
+          language: { __typename: 'Language', ...langByLabel('Hindi') },
+        });
+        family = [...family, created];
+        req.alias = 'createVariant';
+        req.reply({
+          statusCode: 200,
+          body: {
+            data: {
+              createSessionTemplate: {
+                sessionTemplate: {
+                  ...created,
+                  example: created.body,
+                  hasButtons: false,
+                  buttons: null,
+                  buttonType: null,
+                },
+                errors: null,
+                __typename: 'SessionTemplateResult',
+              },
+            },
+          },
+        });
+      } else {
+        req.continue();
+      }
+    });
+  };
+
+  const openAddLanguageFromList = (includeSibling = true) => {
+    interceptFamily({ includeSibling });
+    cy.visit('/template-v2');
+    cy.wait('@sessionTemplatesQuery');
+    cy.get('[data-testid="add-language-icon"]').click();
+    cy.location('pathname').should('eq', '/template-v2/add');
+    cy.wait('@getAnchorTemplate');
+    cy.wait('@sessionTemplatesQuery');
+  };
+
+  beforeEach(function () {
+    cy.login();
+  });
+
+  // ---------- Viewing an existing template directly (/template-v2/:id/edit) ----------
+
+  describe('direct view page', () => {
+    beforeEach(() => {
+      interceptFamily({ mode: 'full' });
+      cy.visit(`/template-v2/${anchorId}/edit`);
+      cy.wait('@getAnchorTemplate');
+      cy.wait('@sessionTemplatesQuery');
+    });
+
+    it('should show the template as read-only with no submit button', () => {
+      cy.get('[data-testid="headerTitle"]').should('contain', familyShortcode);
+      cy.get('input[name="newShortcode"]').should('be.disabled');
+      cy.get('[data-testid="submitActionButton"]').should('not.exist');
+      cy.get('[data-testid="cancelActionButton"]').should('contain', 'Go Back');
+    });
+
+    it('should group language versions by status with the correct counts', () => {
+      cy.get('[data-testid="status-tab-Approved"]').should('contain', '2');
+      cy.get('[data-testid="status-tab-In Progress"]').should('contain', '1');
+      cy.get('[data-testid="status-tab-Rejected"]').should('contain', '1');
+      cy.get('[data-testid="language-version-row"]').should('have.length', 2);
+    });
+
+    it('should switch to the In Progress tab and show the pending variant', () => {
+      cy.get('[data-testid="status-tab-In Progress"]').click();
+      cy.get('[data-testid="language-version-row"]')
+        .should('have.length', 1)
+        .and('contain', 'Hindi');
+    });
+
+    it('should switch to the Rejected tab and show the failed variant', () => {
+      cy.get('[data-testid="status-tab-Rejected"]').click();
+      cy.get('[data-testid="language-version-row"]')
+        .should('have.length', 1)
+        .and('contain', 'English');
+    });
+
+    it('should not show Add Language or Delete controls when opened via the direct link', () => {
+      cy.get('[data-testid="add-language-link"]').should('not.exist');
+      cy.get(`[data-testid="delete-language-${hindiId}"]`).should('not.exist');
+    });
+
+    it('should navigate to a sibling variant page when its View link is clicked', () => {
+      cy.get(`[data-testid="view-language-${hindiId}"]`).click();
+      cy.location('pathname').should('eq', `/template-v2/${hindiId}/edit`);
+    });
+
+    it('should navigate back to the list on clicking Go Back', () => {
+      cy.get('[data-testid="cancelActionButton"]').click();
+      cy.location('pathname').should('eq', '/template-v2');
+    });
+  });
+
+  describe('add language flow', () => {
+    it('should open the anchor in view mode with Add Language and Delete controls', () => {
+      openAddLanguageFromList();
+      cy.get('[data-testid="headerTitle"]').should('contain', familyShortcode);
+      cy.get('[data-testid="add-language-link"]').should('be.visible');
+      cy.get(`[data-testid="delete-language-${hindiId}"]`).should('be.visible');
+    });
+
+    it('should open a blank, editable form for the new language and hide already-used languages', () => {
+      // Anchor-only family: English is already used (by the anchor), so it
+      // must be hidden — Hindi, this org's only other active language, is
+      // what's left to prove still shows up as selectable.
+      openAddLanguageFromList(false);
+      cy.get('[data-testid="add-language-link"]').click();
+
+      cy.get('[data-testid="headerTitle"]').should('contain', 'Add Language');
+      cy.get('input[name="newShortcode"]').should('have.value', familyShortcode).and('be.disabled');
+      cy.get('[data-testid="submitActionButton"]').should('exist');
+
+      cy.get('[data-testid="AutocompleteInput"] input').eq(0).click();
+      cy.get('[role="listbox"]').should('contain', 'Hindi');
+      cy.get('[role="listbox"]').should('not.contain', 'English');
+    });
+
+    it('should submit a new language version with the correct payload', () => {
+      openAddLanguageFromList(false);
+      cy.get('[data-testid="add-language-link"]').click();
+
+      cy.get('[data-testid="AutocompleteInput"] input').eq(0).click().clear().type('Hindi');
+      cy.contains('Hindi').click({ force: true });
+      cy.get('[data-testid="editor-body"]').click().type('Namaste, welcome!').blur({ force: true });
+      cy.get('[data-testid="beneficiaryName"]').click();
+      cy.get('html').click();
+
+      cy.get('[data-testid="submitActionButton"]').click();
+
+      cy.wait('@createVariant').then((interception) => {
+        const input = interception.request.body.variables.input;
+        expect(input.shortcode).to.eq(familyShortcode);
+        expect(input.languageId).to.eq(langByLabel('Hindi').id);
+      });
+      cy.contains('HSM Template created successfully!');
+
+      cy.location('pathname').should('eq', '/template-v2');
+    });
+
+    it('should delete a non-anchor language version after confirmation', () => {
+      openAddLanguageFromList();
+      cy.get(`[data-testid="delete-language-${hindiId}"]`).click();
+
+      cy.get('[data-testid="dialogTitle"]').should('contain', 'Hindi');
+      cy.get('[data-testid="ok-button"]').click();
+
+      cy.wait('@deleteVariant');
+      cy.contains('Template deleted successfully');
+      cy.get(`[data-testid="delete-language-${hindiId}"]`).should('not.exist');
+      cy.get('[data-testid="status-tab-Approved"]').should('contain', '1');
+    });
+  });
+});

--- a/cypress/e2e/template/HSMTemplateV2.spec.ts
+++ b/cypress/e2e/template/HSMTemplateV2.spec.ts
@@ -381,7 +381,8 @@ describe('HSM Template V2', () => {
       expect(input.category).to.eq('UTILITY');
       expect(input.isHsm).to.eq(true);
       expect(input.type).to.eq('TEXT');
-      expect(input.languageId).to.be.a('number');
+      expect(input.languageId).to.be.a('string');
+      expect(input.languageId).to.have.length.greaterThan(0);
       expect(input.attachmentURL).to.eq(undefined);
       expect(input.hasButtons).to.eq(undefined);
     });


### PR DESCRIPTION
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive end-to-end coverage for HSM Template V2.
  * Verified template listing, filtering, creation, validation, tagging, and navigation.
  * Added coverage for message formatting, variables, footers, quick replies, call-to-action controls, WhatsApp forms, and media attachments.
  * Validated attachment options, upload warnings, selection clearing, and media type switching.

<img width="1512" height="815" alt="Screenshot 2026-07-14 at 12 08 57 PM" src="https://github.com/user-attachments/assets/2633b605-989d-415b-bd2c-0ffb8d4103bd" />

<img width="1512" height="819" alt="Screenshot 2026-07-14 at 12 09 05 PM" src="https://github.com/user-attachments/assets/ef45f571-c7db-4725-a9dc-0591b48fe171" />

<img width="1512" height="786" alt="Screenshot 2026-07-14 at 12 09 13 PM" src="https://github.com/user-attachments/assets/012a00a0-af34-47fb-947f-f122e317b735" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive end-to-end coverage for HSM Template V2, including filtering, creation, validation, formatting, dynamic content, buttons, media attachments, tags, and navigation.
  * Added coverage for text-only and Quick Reply template submission payloads.

* **Chores**
  * Updated end-to-end test setup to use the required backend and frontend branches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->